### PR TITLE
Not pulling last version from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vk-bot-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "API for VK bots based on long poll with multi-dispatch send messages (75 per second).",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It is important to update a version after any changes in code to be sure that clients will got last version of lib from `npm i`.

ISSUE: after you added a catch, that prevents appearing an `unhandledRejection` in `.listen()` it wasn't updated on NPM. So, if I'm installing from NPM -- I cannot get last version of code.

PS: don't forget to push to NPM site.